### PR TITLE
Month options

### DIFF
--- a/task/options for month labels.md
+++ b/task/options for month labels.md
@@ -10,4 +10,11 @@ I'll need to add an option or two to drawMonthLabels, and a format function.
 
 
 
+Options
+-------
 
+* Position of label along sector - eg start/middle/end - could be a flag/enum or a real
+* Whether to invert the bottom half of the lablels
+* Whether to rotate the labels
+
+Looks like I've already added some options, nut the invert one isn't oroperly funtional yet.

--- a/task/options for month labels.md
+++ b/task/options for month labels.md
@@ -1,4 +1,13 @@
 Options for month labels
 ========================
 
-[placeholder]
+Carried over from [15 - some cleanup](<[done]/15 - some cleanup.md>).
+
+> remove the drawMonthLabels override in the wall-clock theme
+
+
+I'll need to add an option or two to drawMonthLabels, and a format function.
+
+
+
+

--- a/task/options for month labels.md
+++ b/task/options for month labels.md
@@ -14,7 +14,28 @@ Options
 -------
 
 * Position of label along sector - eg start/middle/end - could be a flag/enum or a real
-* Whether to invert the bottom half of the lablels
+* Whether to invert the bottom half of the labels
 * Whether to rotate the labels
 
-Looks like I've already added some options, nut the invert one isn't oroperly funtional yet.
+Looks like I've already added some options, but the invert one isn't properly functional yet.
+
+
+Merge
+-----
+I've managed to merge the changes from wall-clock into the main drawMonthLabels function, so that the overridden function is no longer needed for wall-clock.
+
+I'm haven't managed to prise the 'invert' option apart from the rotate one yet, but it's probably only really useful in that context anyway.
+I'll leave that one for now, maybe revisit later.
+
+Wrapup
+------
+
+Will close this here, the job of removing the main override is done.
+
+* Added overridable month name formatter
+* Label rotation now specified with a config flag
+* Renamed a lot of angle vars to specify radians or degrees
+* Added sector width for position calcs
+* Month label position can now be specified as a proportion of sector width, eg 0 for the start of the sector (wall-clock), 0.5 for the original layouts
+
+

--- a/yearclock/script/setup.js
+++ b/yearclock/script/setup.js
@@ -57,20 +57,23 @@ function setup() {
 	// Set Up Months
 	config.months = config.monthNames.map(
 		function( monthName, monthNumber ) {
-			const startDate = new Date(config.date.year, monthNumber);
-			const nextMonth = new Date(config.date.year, monthNumber + 1);
-			const endDate   = new Date(nextMonth - 1000);
-			const startAngle = dateRadians(startDate);
-			const endAngle   = dateRadians(endDate);
+			const startDate    = new Date(config.date.year, monthNumber);
+			const nextMonth    = new Date(config.date.year, monthNumber + 1);
+			const endDate      = new Date(nextMonth - 1000);
+			const radiansStart = dateRadians(startDate);
+			const radiansEnd   = dateRadians(endDate);
+			const radiansWidth = radiansEnd - radiansStart;
+
 			const result = {
-				'name'       : monthName,
-				'code'       : config.monthCodes[monthNumber],
-				'startDate'  : new Date(config.date.year, monthNumber),
-				'nextMonth'  : nextMonth,
-				'endDate'    : new Date(nextMonth - 1000),
-				'startAngle' : startAngle,
-				'endAngle'   : endAngle,
-				'midAngle'   : midpoint(startAngle,endAngle),
+				'name'         : monthName,
+				'code'         : config.monthCodes[monthNumber],
+				'startDate'    : new Date(config.date.year, monthNumber),
+				'nextMonth'    : nextMonth,
+				'endDate'      : new Date(nextMonth - 1000),
+				'radiansStart' : radiansStart,
+				'radiansEnd'   : radiansEnd,
+				'radiansWidth' : radiansWidth,
+				'radiansMid'   : midpoint(radiansStart, radiansEnd),
 			}
 			return result;
 		}

--- a/yearclock/theme/common/yearclock.js
+++ b/yearclock/theme/common/yearclock.js
@@ -78,7 +78,10 @@ theme.clock.drawMonthLabels = function() {
 			</text>`;
 		newSvg += labelSvg;
 	}
-	theme.clock.element.innerHTML += `<g class="month label">${newSvg}</g>`;
+	theme.clock.element.innerHTML +=
+		`<g class="month label monthLabels">
+			${newSvg}
+		</g>`;
 }/* drawMonthLabels */
 
 

--- a/yearclock/theme/common/yearclock.js
+++ b/yearclock/theme/common/yearclock.js
@@ -15,7 +15,7 @@ theme.clock.yearHandLength    = 1030;
 theme.clock.dateLabel         = 500;
 
 theme.clock.monthLabel = {};
-theme.clock.monthLabel.position = 0.5;
+theme.clock.monthLabel.sectorPosition = 0.5;
 theme.clock.monthLabel.rotate = true;
 theme.clock.monthLabel.invert = true;
 
@@ -49,7 +49,7 @@ theme.clock.drawMonthSectors = function() {
 	let newSvg = '';
 	for (let month of config.months)
 	{
-		const sectorPath = sector(month.startAngle, month.endAngle, theme.clock.innerRadius, theme.clock.outerRadius );
+		const sectorPath = sector(month.radiansStart, month.radiansEnd, theme.clock.innerRadius, theme.clock.outerRadius );
 		sectorSvg = `<path d="${sectorPath}" class="sector ${month.code}"></path>`;
 		newSvg += sectorSvg;
 	}
@@ -63,13 +63,15 @@ theme.clock.drawMonthLabels = function() {
 	let newSvg = '';
 	for (let month of config.months)
 	{
-		const center     = polarPoint(month.midAngle, theme.clock.monthLabelRadius);
+		const radiansLabel = month.radiansStart + (month.radiansWidth * theme.clock.monthLabel.sectorPosition);
+
+		const center     = polarPoint(radiansLabel, theme.clock.monthLabelRadius);
 		let transform = '';
 
 		if (theme.clock.monthLabel.rotate)
 		{
-			const invert    = (Math.cos(month.midAngle) < 0);
-			const rotate    = degrees(month.midAngle) + ((invert) ? 180 : 0);
+			const invert    = (Math.cos(radiansLabel) < 0);
+			const rotate    = degrees(radiansLabel) + ((invert) ? 180 : 0);
 			transform = `rotate(${rotate}, ${center.x}, ${center.y})`;
 		}
 		const labelSvg =

--- a/yearclock/theme/common/yearclock.js
+++ b/yearclock/theme/common/yearclock.js
@@ -73,12 +73,16 @@ theme.clock.drawMonthLabels = function() {
 			transform = `rotate(${rotate}, ${center.x}, ${center.y})`;
 		}
 		const labelSvg =
-			`<text x="${center.x}" y="${center.y}" transform="${transform}">${month.name}</text>`;
+			`<text x="${center.x}" y="${center.y}" transform="${transform}">
+				${formatMonth(month.name)}
+			</text>`;
 		newSvg += labelSvg;
 	}
 	theme.clock.element.innerHTML += `<g class="month label">${newSvg}</g>`;
 }/* drawMonthLabels */
 
+
+function formatMonth(name) { return name }
 
 
 /* drawYearDayTicks

--- a/yearclock/theme/wall-clock/yearclock.js
+++ b/yearclock/theme/wall-clock/yearclock.js
@@ -44,7 +44,7 @@ theme.clock.drawClock = function()
 /* drawMonthLabels
 */
 theme.clock.drawMonthLabels = function() {
-	newSvg = '';
+	let newSvg = '';
 	for (let month of config.months)
 	{
 		const center     = polarPoint(month.startAngle, theme.clock.monthLabelRadius);
@@ -54,8 +54,10 @@ theme.clock.drawMonthLabels = function() {
 			</text>`;
 		newSvg += labelSvg;
 	}
-	theme.clock.element.innerHTML +=
-		`<g class="month label monthLabels">${newSvg}</g>`;
+	theme.clock.element.innerHTML += `
+		<g class="month label monthLabels">
+			${newSvg}
+		</g>`;
 }/* drawMonthLabels */
 
 

--- a/yearclock/theme/wall-clock/yearclock.js
+++ b/yearclock/theme/wall-clock/yearclock.js
@@ -13,7 +13,7 @@ theme.clock.weekendTickLength = 55;
 theme.clock.dateLabel         = new Point(0,430);
 
 theme.clock.monthLabel = {};
-theme.clock.monthLabel.position = 0;
+theme.clock.monthLabel.sectorPosition = 0;
 theme.clock.monthLabel.rotate = false;
 theme.clock.monthLabel.invert = false;
 
@@ -42,7 +42,7 @@ theme.clock.drawClock = function()
 
 
 /* drawMonthLabels
-*/
+* /
 theme.clock.drawMonthLabels = function() {
 	let newSvg = '';
 	for (let month of config.months)
@@ -58,7 +58,7 @@ theme.clock.drawMonthLabels = function() {
 		<g class="month label monthLabels">
 			${newSvg}
 		</g>`;
-}/* drawMonthLabels */
+}/ * drawMonthLabels */
 
 
 

--- a/yearclock/theme/wall-clock/yearclock.js
+++ b/yearclock/theme/wall-clock/yearclock.js
@@ -49,8 +49,15 @@ theme.clock.drawMonthLabels = function() {
 	{
 		const center     = polarPoint(month.startAngle, theme.clock.monthLabelRadius);
 		const labelSvg =
-			`<text x="${center.x}" y="${center.y}">${month.name.slice(0,3)}</text>`;
+			`<text x="${center.x}" y="${center.y}">
+				${formatMonth(month.name)}
+			</text>`;
 		newSvg += labelSvg;
 	}
-	theme.clock.element.innerHTML += `<g class="month label monthLabels">${newSvg}</g>`;
+	theme.clock.element.innerHTML +=
+		`<g class="month label monthLabels">${newSvg}</g>`;
 }/* drawMonthLabels */
+
+
+
+function formatMonth(name) { return name.slice(0,3) }

--- a/yearclock/theme/wall-clock/yearclock.js
+++ b/yearclock/theme/wall-clock/yearclock.js
@@ -41,25 +41,4 @@ theme.clock.drawClock = function()
 
 
 
-/* drawMonthLabels
-* /
-theme.clock.drawMonthLabels = function() {
-	let newSvg = '';
-	for (let month of config.months)
-	{
-		const center     = polarPoint(month.startAngle, theme.clock.monthLabelRadius);
-		const labelSvg =
-			`<text x="${center.x}" y="${center.y}">
-				${formatMonth(month.name)}
-			</text>`;
-		newSvg += labelSvg;
-	}
-	theme.clock.element.innerHTML += `
-		<g class="month label monthLabels">
-			${newSvg}
-		</g>`;
-}/ * drawMonthLabels */
-
-
-
 function formatMonth(name) { return name.slice(0,3) }


### PR DESCRIPTION
* Added overridable month name formatter
* Label rotation now specified with a config flag
* Renamed a lot of angle vars to specify radians or degrees
* Added sector width for position calcs
* Month label position can now be specified as a proportion of sector width, eg 0 for the start of the sector (wall-clock), 0.5 for the original layouts