### PR TITLE
Vintage clock followup

### DIFF
--- a/task/v1/1.3 - vintage clock.md
+++ b/task/v1/1.3 - vintage clock.md
@@ -320,3 +320,15 @@ New tasks:
 Additionally a few days ago I added a GitHub pages build for this project, so the clock is now live out there on the internet; there are various tidies I'd like to make in respect to that.
 
 
+
+
+Follow-up
+---------
+
+A few little additional visual tweaks:
+* Update text centering for day-name ring
+* Push the month numbers out a little bit to connect with month-name ring better
+* Lengthen year hand and make the disc bigger so it can be seen under the month-hand disc
+* Specify 'Noto Serif' as the primary font so that chromium uses it (on linux at least). Will need some more platform testing here.
+* Add a simple emboss to the body and face. Looks nice, but on chromium this weirdly lightens the shadows (???) I think chromium does it wrong fwiw.
+

--- a/task/v1/1.3 - vintage clock.md
+++ b/task/v1/1.3 - vintage clock.md
@@ -331,4 +331,4 @@ A few little additional visual tweaks:
 * Lengthen year hand and make the disc bigger so it can be seen under the month-hand disc
 * Specify 'Noto Serif' as the primary font so that chromium uses it (on linux at least). Will need some more platform testing here.
 * Add a simple emboss to the body and face. Looks nice, but on chromium this weirdly lightens the shadows (???) I think chromium does it wrong fwiw.
-
+* Add a little pin to the hand centre

--- a/yearclock/theme/vintage/theme.class.js
+++ b/yearclock/theme/vintage/theme.class.js
@@ -24,7 +24,7 @@ themeClass['vintage'] = class extends ThemeBase {
 
 
 	monthNumber = {
-		radius         : 900,
+		radius         : 950,
 		sectorPosition : 0.5,
 		rotate         : true,
 		invert         : false,
@@ -44,7 +44,7 @@ themeClass['vintage'] = class extends ThemeBase {
 	};
 
 	dayNumber = {
-		radius         : 600,
+		radius         : 615,
 		sectorPosition : 0.5,
 		rotate         : true,
 		invert         : false,
@@ -58,7 +58,7 @@ themeClass['vintage'] = class extends ThemeBase {
 
 	handConfig = {
 		year : {
-			length : 850,
+			length : 900,
 			function : ()=>this.getHand1,
 		},
 		month : {

--- a/yearclock/theme/vintage/theme.class.js
+++ b/yearclock/theme/vintage/theme.class.js
@@ -118,6 +118,8 @@ themeClass['vintage'] = class extends ThemeBase {
 				</svg>
 
 				${this.getHands(displayDate, this.handConfig)}
+				${this.getPin()}
+
 			</svg>
 		`;
 
@@ -318,6 +320,10 @@ themeClass['vintage'] = class extends ThemeBase {
 			`<path class="label favicon" d="M 259 966 L -707 -707 L 966 259 L -966 259 L 707 -707 L -259 966 L -259 -966 L 707 707 L -966 -259 L 966 -259 L -707 707 L 259 -966  Z"/>`;
 			//'<path class="label favicon" d="M 259 966 L -966 -259 L 707 -707 M -259 966 L -707 -707 L 966 -259 M -707 707 L -259 -966 L 966 259 M -966 259 L 259 -966 L 707 707  Z"></path>';
 		return path;
+	}
+
+	getPin = function() {
+		return `<circle class="pin" x="0" y="0" r="10"/>`
 	}
 
 

--- a/yearclock/theme/vintage/theme.class.js
+++ b/yearclock/theme/vintage/theme.class.js
@@ -204,9 +204,9 @@ themeClass['vintage'] = class extends ThemeBase {
 
 		const tipRadius = 5;
 
-		const pinRadius = 25;
-		const pinX = pinRadius * (3/5);
-		const pinY = pinRadius * (4/5);
+		const pinRadius = 60;
+		const pinX = pinRadius * (5/13);
+		const pinY = pinRadius * (12/13);
 		/* Need to use a better pythagorean triad or do the trig properly */
 
 		const path = `

--- a/yearclock/theme/vintage/theme.class.js
+++ b/yearclock/theme/vintage/theme.class.js
@@ -211,23 +211,23 @@ themeClass['vintage'] = class extends ThemeBase {
 
 		const tipRadius = 5;
 
-		const pinRadius = 60;
-		const pinX = pinRadius * (5/13);
-		const pinY = pinRadius * (12/13);
+		const discRadius = 60;
+		const discX = discRadius * (5/13);
+		const discY = discRadius * (12/13);
 		/* Need to use a better pythagorean triad or do the trig properly */
 
 		const path = `
 			M -${tipRadius}, -${param.length}
 			A ${tipRadius},${tipRadius} 0 1 1 ${tipRadius}, -${param.length}
 
-			L ${pinX} -${pinY}
-			A ${pinRadius},${pinRadius} 0 0 1 ${pinX}, ${pinY}
+			L ${discX} -${discY}
+			A ${discRadius},${discRadius} 0 0 1 ${discX}, ${discY}
 
 			L ${width} ${tail}
 			L -${width} ${tail}
 
-			L -${pinX} ${pinY}
-			A ${pinRadius},${pinRadius} 0 0 1 -${pinX}, -${pinY}
+			L -${discX} ${discY}
+			A ${discRadius},${discRadius} 0 0 1 -${discX}, -${discY}
 
 			Z`;
 		const svg =
@@ -258,9 +258,9 @@ themeClass['vintage'] = class extends ThemeBase {
 		const circleX = circleRadius * (5/13);
 		const circleY = circleRadius * (12/13);
 
-		const pinRadius = 50;
-		const pinX = pinRadius * (5/13);
-		const pinY = pinRadius * (12/13);
+		const discRadius = 50;
+		const discX = discRadius * (5/13);
+		const discY = discRadius * (12/13);
 		/* Need to use a better pythagorean triad or do the trig properly */
 
 		/*
@@ -275,14 +275,14 @@ themeClass['vintage'] = class extends ThemeBase {
 			A ${circleRadius},${circleRadius} 0 0 1 ${circleX} -${circle-circleY}
 
 
-			L ${pinX} -${pinY}
-			A ${pinRadius},${pinRadius} 0 0 1 ${pinX}, ${pinY}
+			L ${discX} -${discY}
+			A ${discRadius},${discRadius} 0 0 1 ${discX}, ${discY}
 
 			L ${width} ${tail}
 			L -${width} ${tail}
 
-			L -${pinX} ${pinY}
-			A ${pinRadius},${pinRadius} 0 0 1 -${pinX}, -${pinY}
+			L -${discX} ${discY}
+			A ${discRadius},${discRadius} 0 0 1 -${discX}, -${discY}
 
 			L ${-circleX} -${circle-circleY}
 			A ${circleRadius},${circleRadius} 0 0 1 0, -${circle+circleRadius}

--- a/yearclock/theme/vintage/theme.class.js
+++ b/yearclock/theme/vintage/theme.class.js
@@ -154,6 +154,13 @@ themeClass['vintage'] = class extends ThemeBase {
 					<stop class="stop2" offset="50%" />
 					<stop class="stop3" offset="100%" />
 				</linearGradient>
+				<filter id="emboss-top">
+					<feConvolveMatrix kernelMatrix="
+						0 1 0
+						0 1 0
+						0 -1 0
+					"/>
+				</filter>
 			</defs>
 		`;
 		return result;

--- a/yearclock/theme/vintage/theme.css
+++ b/yearclock/theme/vintage/theme.css
@@ -45,14 +45,14 @@ svg.yearclock {
 		fill: url(#Gradient1);
 		stroke: grey;
 		stroke-width: 3;
-		filter: drop-shadow(0px 40px 20px #444b);
+		filter: url(#emboss-top) drop-shadow(0px 40px 20px #444b);
 	}
 
 	.face {
 		fill: ivory; /* cornsilk */
 		stroke: silver;
 		stroke-width: 10;
-		filter: drop-shadow(0px 10px 10px gray);
+		filter: url(#emboss-top) drop-shadow(0px 10px 10px #444b);
 	}
 
 }/* svg.yearclock */

--- a/yearclock/theme/vintage/theme.css
+++ b/yearclock/theme/vintage/theme.css
@@ -55,6 +55,12 @@ svg.yearclock {
 		filter: url(#emboss-top) drop-shadow(0px 10px 10px #444b);
 	}
 
+	circle.pin {
+		stroke: var(--darkGrey);
+		fill: #444b;
+		stroke-width: 2;
+	}
+
 }/* svg.yearclock */
 
 
@@ -175,3 +181,5 @@ svg.yearclock path.hand2  {
 
 	fill: url(#lensGradient);
 }
+
+

--- a/yearclock/theme/vintage/theme.css
+++ b/yearclock/theme/vintage/theme.css
@@ -106,14 +106,13 @@ svg.yearclock .day .sector.weekend
 
 svg.yearclock .label {
 	text-anchor: middle;
-	dominant-baseline: middle;
+	dominant-baseline: central;
 	fill: var(--darkGrey);
 	stroke: none;
 	font-variant: small-caps;
 
 	&.monthName text {
 		font-size: 1em;
-		dominant-baseline: central;
 	}
 
 	&.monthNumber text{
@@ -132,13 +131,11 @@ svg.yearclock .label {
 	&.dateLabel {
 		text-anchor: middle;
 		font-size: 4em;
-		dominant-baseline: central;
 	}
 
 	&.favicon {
 		text-anchor: middle;
 		font-size: 3em;
-		dominant-baseline: central;
 		fill: var(--sectordark);
 		fill-rule: evenodd; /* nonzero, evenodd */
 		stroke: var(--darkGrey);

--- a/yearclock/theme/vintage/theme.css
+++ b/yearclock/theme/vintage/theme.css
@@ -3,24 +3,17 @@
 */
 svg.yearclock {
 
+	font-size: 48px;
+	font-family: serif;
+
+
 	--lightblue: #ade9;
 	--lightpink: #fbc;
 	--ivory: #ffee;
 
 	--sectorlight: cornsilk; /* #fff7 */
 	--sectordark: wheat;
-
 	--darkGrey: #222c;
-
-
-	/*
-	background: repeating-linear-gradient(
-		45deg,
-		ivory,
-		ivory 2vw,
-		gold 2.4vw,
-		gold 2.6vw
-	); */
 
 
 	background:
@@ -45,15 +38,26 @@ svg.yearclock {
 			gold 3vh,
 			ivory 3.3vh
 		);
-}
 
-svg.yearclock {
 
-	/* background-color: burlywood; */
-	/* background-image: url(#Gradient1); */
-	font-size: 48px;
-	font-family: serif;/*  cursive, */
-}
+	.body {
+		/* fill: wheat; */
+		fill: url(#Gradient1);
+		stroke: grey;
+		stroke-width: 3;
+		filter: drop-shadow(0px 40px 20px #444b);
+	}
+
+	.face {
+		fill: ivory; /* cornsilk */
+		stroke: silver;
+		stroke-width: 10;
+		filter: drop-shadow(0px 10px 10px gray);
+	}
+
+}/* svg.yearclock */
+
+
 
 
 .stop1 {
@@ -66,24 +70,6 @@ svg.yearclock {
 .stop3 {
 	stop-color: brown;
 }
-
-
-svg.yearclock .body   {
-	/* fill: wheat; */
-	fill: url(#Gradient1);
-	stroke: grey;
-	stroke-width: 3;
-	filter: drop-shadow(0px 30px 20px #444);
-}
-
-
-svg.yearclock .face   {
-	fill: ivory; /* cornsilk */
-	stroke: silver;
-	stroke-width: 10;
-	filter: drop-shadow(0px 10px 10px gray);
-}
-
 
 
 svg.yearclock .sector {

--- a/yearclock/theme/vintage/theme.css
+++ b/yearclock/theme/vintage/theme.css
@@ -4,7 +4,7 @@
 svg.yearclock {
 
 	font-size: 48px;
-	font-family: serif;
+	font-family: Noto Serif, serif;
 
 
 	--lightblue: #ade9;


### PR DESCRIPTION
A few little additional visual tweaks:
* Update text centering for day-name ring
* Push the month numbers out a little bit to connect with month-name ring better
* Lengthen year hand and make the disc bigger so it can be seen under the month-hand disc
* Specify 'Noto Serif' as the primary font so that chromium uses it (on linux at least). Will need some more platform testing here.
* Add a simple emboss to the body and face. Looks nice, but on chromium this weirdly lightens the shadows (???) I think chromium does it wrong fwiw.
* Add a little pin to the hand centre
